### PR TITLE
fix deprecated warning

### DIFF
--- a/DataCollector/CassandraDataCollector.php
+++ b/DataCollector/CassandraDataCollector.php
@@ -40,20 +40,14 @@ class CassandraDataCollector extends DataCollector
     }
 
     /**
-     * Collect the data.
-     *
-     * @param Request    $request   The request object
-     * @param Response   $response  The response object
-     * @param \Exception $exception An exception
+     * {@inheritdoc}
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
     }
 
     /**
-     * Return the name of the collector.
-     *
-     * @return string data collector name
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -180,5 +174,12 @@ class CassandraDataCollector extends DataCollector
         }
 
         return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
     }
 }

--- a/DependencyInjection/CassandraExtension.php
+++ b/DependencyInjection/CassandraExtension.php
@@ -28,7 +28,7 @@ class CassandraExtension extends Extension
         $loader->load('services.yml');
 
         $ormConfig = [];
-        if (isset($config['orm']) && $config['orm']) {
+        if (!empty($config['orm'])) {
             $ormConfig = $config['orm'];
         }
         $this->metadataFactoryLoad($container, $ormConfig);
@@ -64,13 +64,14 @@ class CassandraExtension extends Extension
             $definition->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')]);
         }
 
-        $container->setDefinition('cassandra.connection.'.$connectionId, $definition);
+        $container->setDefinition(sprintf('cassandra.connection.%s', $connectionId), $definition);
 
         $container
             ->register(sprintf('cassandra.%s_entity_manager', $connectionId), 'CassandraBundle\\Cassandra\\ORM\\EntityManager')
-            ->addArgument(new Reference("cassandra.connection.$connectionId"))
+            ->addArgument(new Reference(sprintf('cassandra.connection.%s', $connectionId)))
             ->addArgument(new Reference('cassandra.factory.metadata'))
-            ->addArgument(new Reference('logger'));
+            ->addArgument(new Reference('logger'))
+            ->setPublic(true);
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,3 +8,4 @@ services:
     cassandra.tools.schema_create:
         class: "CassandraBundle\\Cassandra\\ORM\\Tools\\SchemaCreate"
         arguments: ["@service_container"]
+        public: true

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require-dev": {
         "atoum/atoum": "~2.0",
-        "symfony/framework-bundle": "~2.8|~3.0",
-        "symfony/yaml": "~2.8|~3.0",
-        "symfony/console": "~2.8|~3.0",
+        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/yaml": "~2.7|~3.0|~4.0",
+        "symfony/console": "~2.7|~3.0|~4.0",
         "datastax/php-driver": "v1.3.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require-dev": {
         "atoum/atoum": "~2.0",
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
-        "symfony/console": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.8|~3.0",
+        "symfony/yaml": "~2.8|~3.0",
+        "symfony/console": "~2.8|~3.0",
         "datastax/php-driver": "v1.3.2"
     },
     "autoload": {


### PR DESCRIPTION
Implementing DataCollectorInterface without a reset() method has been deprecated and will be unsupported in 4.0. [See here](https://github.com/symfony/symfony/blob/3.4/UPGRADE-3.4.md#httpkernel)

Definitions and aliases will be made private by default in 4.0. You should either use service injection or explicitly define your services as public if you really need to inject the container. [See here](https://github.com/symfony/symfony/blob/3.4/UPGRADE-3.4.md#dependencyinjection)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hendra-huang/cassandrabundle/7)
<!-- Reviewable:end -->
