### PR TITLE
Decode values of type Date and Time

### DIFF
--- a/Cassandra/ORM/EntityManager.php
+++ b/Cassandra/ORM/EntityManager.php
@@ -309,6 +309,14 @@ class EntityManager implements Session, EntityManagerInterface
             if ($columnValue instanceOf \Cassandra\Timestamp) {
                 return $columnValue->time();
             }
+            // Cassandra\Date class
+            if ($columnValue instanceOf \Cassandra\Date) {
+                return $columnValue->seconds();
+            }
+            // Cassandra\Time class
+            if ($columnValue instanceOf \Cassandra\Time) {
+                return $columnValue->seconds();
+            }
             // Cassandra\Map class
             if ($columnValue instanceOf \Cassandra\Map) {
                 $decodedKeys = [];


### PR DESCRIPTION
\Cassandra\Timestamp values are decoded to a number of seconds since Epoch but \Cassandra\Date and \Cassandra\Time values are decoded by casting them to strings which leads to values such as 'Cassandra\Date(seconds=$seconds)' 'Cassandra\Time(nanoseconds=$nanoseconds)'. This patch harmonizes everything by returning a number of seconds since Epoch in all cases.

We could also return a PHP \DateTime object directly, by using \Cassandra\Date a,d \Cassandra\Timestamp ::toDateTime() method, which would give more flexibility to the user of the entities. What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hendra-huang/cassandrabundle/8)
<!-- Reviewable:end -->
