### PR TITLE
Add tableOptions field in table orm mapping annotation

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -1,2 +1,2 @@
 <?php
-$runner->addTestsFromDirectory(__DIR__.'/src/Tests');
+$runner->addTestsFromDirectory(__DIR__.'/Tests');

--- a/Cassandra/ORM/Mapping/ClassMetadataFactory.php
+++ b/Cassandra/ORM/Mapping/ClassMetadataFactory.php
@@ -161,7 +161,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      *
      * NOTE: This is only useful in very special cases, like when generating proxy classes.
      *
-     * @param string        $className
+     * @param string $className
      * @param ClassMetadata $class
      */
     public function setMetadataFor($className, $class)
@@ -235,12 +235,12 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
     {
         if (count($this->mappingsConfig) <= 0) {
-            return $namespaceAlias."\\Entity\\".$simpleClassName;
+            return $namespaceAlias . "\\Entity\\" . $simpleClassName;
         }
 
         foreach ($this->mappingsConfig as $name => $config) {
             if ($namespaceAlias == $name) {
-                return $config['prefix']."\\".$simpleClassName;
+                return $config['prefix'] . "\\" . $simpleClassName;
             }
         }
     }

--- a/Cassandra/ORM/Mapping/ClassMetadataFactory.php
+++ b/Cassandra/ORM/Mapping/ClassMetadataFactory.php
@@ -186,6 +186,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
             $classMetadata->table['primaryKeys'] = $classAnnotation->primaryKeys;
             $classMetadata->table['defaultTtl'] = $classAnnotation->defaultTtl;
             $classMetadata->table['ifNoExist'] = $classAnnotation->ifNoExist;
+            $classMetadata->table['tableOptions'] = $classAnnotation->tableOptions;
         }
 
         // Save the field mapping to metadata

--- a/Cassandra/ORM/Mapping/Table.php
+++ b/Cassandra/ORM/Mapping/Table.php
@@ -40,11 +40,11 @@ final class Table extends Annotation
      */
     public $ifNoExist = null;
 
-	/**
-	 * @var array
-	 */
+    /**
+     * @var array
+     */
     public $tableOptions = [
-		'compactStorage' => false,
-		'clusteringOrder' => null,
-	];
+        'compactStorage' => false,
+        'clusteringOrder' => null,
+    ];
 }

--- a/Cassandra/ORM/Mapping/Table.php
+++ b/Cassandra/ORM/Mapping/Table.php
@@ -39,4 +39,12 @@ final class Table extends Annotation
      * @var bool
      */
     public $ifNoExist = null;
+
+	/**
+	 * @var array
+	 */
+    public $tableOptions = [
+		'compactStorage' => false,
+		'clusteringOrder' => null,
+	];
 }

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -19,10 +19,10 @@ class SchemaManager
         $this->connection->execute($statement);
     }
 
-    public function createTable($name, $fields, $primaryKeyFields = [])
+    public function createTable($name, $fields, $primaryKeyFields = [], $tableOptions = [])
     {
         $fieldsWithType = array_map(function ($field) { return $field['columnName'].' '.$field['type']; }, $fields);
-        $primaryKeyCQL = '';
+        $primaryKeyCQL = $tableOptionsCQL = '';
         if (count($primaryKeyFields) > 0) {
             $partitionKey = $primaryKeyFields[0];
             // if there is composite partition key
@@ -32,7 +32,22 @@ class SchemaManager
             $primaryKeyCQL = sprintf(',PRIMARY KEY (%s)', implode(',', $primaryKeyFields));
         }
 
-        $this->_exec(sprintf('CREATE TABLE %s (%s%s);', $name, implode(',', $fieldsWithType), $primaryKeyCQL));
+        if (!empty($tableOptions)) {
+			$tableOptionsParamCQL = [];
+			if (isset($tableOptions['compactStorage']) && false !== $tableOptions['compactStorage']) {
+				$tableOptionsParamCQL[] = 'COMPACT STORAGE';
+			}
+
+			if (isset($tableOptions['clusteringOrder']) && !is_null($tableOptions['clusteringOrder'])) {
+				$tableOptionsParamCQL[] = sprintf('CLUSTERING ORDER BY (%s)', $tableOptions['clusteringOrder']);
+			}
+
+			if (!empty($tableOptionsParamCQL)) {
+				$tableOptionsCQL = sprintf(' WITH %s', implode(' AND ', $tableOptionsParamCQL));
+			}
+		}
+
+        $this->_exec(sprintf('CREATE TABLE %s (%s%s)%s;', $name, implode(',', $fieldsWithType), $primaryKeyCQL, $tableOptionsCQL));
     }
 
     public function dropTable($name)

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -21,7 +21,9 @@ class SchemaManager
 
     public function createTable($name, $fields, $primaryKeyFields = [], $tableOptions = [])
     {
-        $fieldsWithType = array_map(function ($field) { return $field['columnName'].' '.$field['type']; }, $fields);
+        $fieldsWithType = array_map(function ($field) {
+            return $field['columnName'] . ' ' . $field['type'];
+        }, $fields);
         $primaryKeyCQL = $tableOptionsCQL = '';
         if (count($primaryKeyFields) > 0) {
             $partitionKey = $primaryKeyFields[0];
@@ -33,19 +35,19 @@ class SchemaManager
         }
 
         if (!empty($tableOptions)) {
-			$tableOptionsParamCQL = [];
-			if (isset($tableOptions['compactStorage']) && false !== $tableOptions['compactStorage']) {
-				$tableOptionsParamCQL[] = 'COMPACT STORAGE';
-			}
+            $tableOptionsParamCQL = [];
+            if (isset($tableOptions['compactStorage']) && false !== $tableOptions['compactStorage']) {
+                $tableOptionsParamCQL[] = 'COMPACT STORAGE';
+            }
 
-			if (isset($tableOptions['clusteringOrder']) && !is_null($tableOptions['clusteringOrder'])) {
-				$tableOptionsParamCQL[] = sprintf('CLUSTERING ORDER BY (%s)', $tableOptions['clusteringOrder']);
-			}
+            if (isset($tableOptions['clusteringOrder']) && !is_null($tableOptions['clusteringOrder'])) {
+                $tableOptionsParamCQL[] = sprintf('CLUSTERING ORDER BY (%s)', $tableOptions['clusteringOrder']);
+            }
 
-			if (!empty($tableOptionsParamCQL)) {
-				$tableOptionsCQL = sprintf(' WITH %s', implode(' AND ', $tableOptionsParamCQL));
-			}
-		}
+            if (!empty($tableOptionsParamCQL)) {
+                $tableOptionsCQL = sprintf(' WITH %s', implode(' AND ', $tableOptionsParamCQL));
+            }
+        }
 
         $this->_exec(sprintf('CREATE TABLE %s (%s%s)%s;', $name, implode(',', $fieldsWithType), $primaryKeyCQL, $tableOptionsCQL));
     }

--- a/Cassandra/ORM/Tools/SchemaCreate.php
+++ b/Cassandra/ORM/Tools/SchemaCreate.php
@@ -39,10 +39,11 @@ class SchemaCreate
                 $tableName = $metadata->table['name'];
                 $indexes = $metadata->table['indexes'];
                 $primaryKeys = $metadata->table['primaryKeys'];
+                $tableOptions = $metadata->table['tableOptions'];
 
                 if ($tableName) {
                     $schemaManager->dropTable($tableName);
-                    $schemaManager->createTable($tableName, $metadata->fieldMappings, $primaryKeys);
+                    $schemaManager->createTable($tableName, $metadata->fieldMappings, $primaryKeys, $tableOptions);
                     $schemaManager->createIndexes($tableName, $indexes);
                 }
             }

--- a/Cassandra/ORM/Tools/SchemaCreate.php
+++ b/Cassandra/ORM/Tools/SchemaCreate.php
@@ -19,13 +19,13 @@ class SchemaCreate
         $schemaManager = $em->getSchemaManager();
 
         // Get all files in src/*/Entity directories
-        $path = $this->container->getParameter('kernel.root_dir').'/../src';
+        $path = $this->container->getParameter('kernel.root_dir') . '/../src';
         $iterator = new \RegexIterator(
             new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
                 \RecursiveIteratorIterator::LEAVES_ONLY
             ),
-            '/^.+'.preg_quote('.php').'$/i',
+            '/^.+' . preg_quote('.php') . '$/i',
             \RecursiveRegexIterator::GET_MATCH
         );
         foreach ($iterator as $file) {

--- a/Tests/Fixtures/default-config.yml
+++ b/Tests/Fixtures/default-config.yml
@@ -6,5 +6,6 @@ cassandra:
         - '127.0.0.1'
         - '127.0.0.2'
         - '127.0.0.3'
+      protocol_version: 3
       user: ''
       password: ''

--- a/Tests/Units/Cassandra/ORM/SchemaManager.php
+++ b/Tests/Units/Cassandra/ORM/SchemaManager.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace CassandraBundle\Tests\Units\Cassandra\ORM;
+
+use mageekguy\atoum\test;
+use CassandraBundle\Cassandra\ORM\SchemaManager as TestedSchemaManager;
+
+class SchemaManager extends test
+{
+	/**
+	 * @dataProvider tableConfigProvider
+	 */
+    public function testCreateTable($tableName, $fields, $primaryKeys, $tableOptions, $expectedCQL)
+    {
+//    	$tableName = 'test';
+//		$fields = [
+//			['columnName' => 'id', 'type' => 'uuid'],
+//			['columnName' => 'name', 'type' => 'text'],
+//		];
+//		$primaryKeys = ['id'];
+//		$tableOptions = ['compactStorage' => true];
+//		$expectedCQL = 'CREATE TABLE test (id uuid,name text,PRIMARY KEY (id)) WITH COMPACT STORAGE;';
+		$this
+			->and($connectionMock = $this->getConnectionMock())
+			->and($clusterMock = $this->getClusterMock())
+			->and($sessionMock = $this->getSessionMock())
+			->and($clusterMock->getMockController()->connect = $sessionMock)
+			->and($connectionMock->setCluster($clusterMock))
+			->given($testedClass = new TestedSchemaManager($connectionMock))
+			->if($testedClass->createTable($tableName, $fields, $primaryKeys, $tableOptions))
+				->mock($connectionMock)
+				->call('prepare')
+				->withIdenticalArguments($expectedCQL)->once()
+				->call('execute')
+				->once()
+        ;
+    }
+
+    protected function tableConfigProvider()
+	{
+		return [
+			[
+				'test',
+				[
+					['columnName' => 'id', 'type' => 'uuid'],
+					['columnName' => 'name', 'type' => 'text'],
+				],
+				['id'],
+				['compactStorage' => true],
+				'CREATE TABLE test (id uuid,name text,PRIMARY KEY (id)) WITH COMPACT STORAGE;'
+			],
+			[
+				'test',
+				[
+					['columnName' => 'id', 'type' => 'uuid'],
+					['columnName' => 'name', 'type' => 'text'],
+					['columnName' => 'lastname', 'type' => 'text'],
+					['columnName' => 'date', 'type' => 'timestamp'],
+				],
+				['id', 'date'],
+				[],
+				'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date));'
+			],
+			[
+				'test',
+				[
+					['columnName' => 'id', 'type' => 'uuid'],
+					['columnName' => 'name', 'type' => 'text'],
+					['columnName' => 'lastname', 'type' => 'text'],
+					['columnName' => 'date', 'type' => 'timestamp'],
+				],
+				['id', 'date'],
+				['clusteringOrder' => 'date DESC'],
+				'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH CLUSTERING ORDER BY (date DESC);'
+			],
+			[
+				'test',
+				[
+					['columnName' => 'id', 'type' => 'uuid'],
+					['columnName' => 'name', 'type' => 'text'],
+					['columnName' => 'lastname', 'type' => 'text'],
+					['columnName' => 'date', 'type' => 'timestamp'],
+				],
+				['id', 'date'],
+				['compactStorage' => true, 'clusteringOrder' => 'date DESC'],
+				'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (date DESC);'
+			],
+		];
+	}
+
+    private function getConnectionMock()
+    {
+        $mockConnection = new \mock\CassandraBundle\Cassandra\Connection(
+			[
+				'keyspace' => 'test',
+				'hosts' => ['127.0.0.1'],
+				'user' => '',
+				'password' => '',
+				'retries' => ['sync_requests' => 1],
+			]
+		);
+        return $mockConnection;
+    }
+
+	private function getClusterMock()
+	{
+		$this->getMockGenerator()->shuntParentClassCalls();
+
+		return new \mock\Cassandra\Cluster();
+	}
+
+	private function getSessionMock($retry = 0, $error = false)
+	{
+		$this->getMockGenerator()->shuntParentClassCalls();
+
+		$session = new \mock\Cassandra\Session();
+		$session->getMockController()->executeAsync = new \mock\Cassandra\Future();
+		$session->getMockController()->prepareAsync = new \mock\Cassandra\Future();
+
+		$session->getMockController()->execute = function () use (&$retry, $error) {
+			if (($error && $retry <= 0) || ($retry > 0)) {
+				--$retry;
+				throw new \Cassandra\Exception\RuntimeException('runtime error');
+			}
+		};
+
+		return $session;
+	}
+}

--- a/Tests/Units/Cassandra/ORM/SchemaManager.php
+++ b/Tests/Units/Cassandra/ORM/SchemaManager.php
@@ -7,123 +7,114 @@ use CassandraBundle\Cassandra\ORM\SchemaManager as TestedSchemaManager;
 
 class SchemaManager extends test
 {
-	/**
-	 * @dataProvider tableConfigProvider
-	 */
+    /**
+     * @dataProvider tableConfigProvider
+     */
     public function testCreateTable($tableName, $fields, $primaryKeys, $tableOptions, $expectedCQL)
     {
-//    	$tableName = 'test';
-//		$fields = [
-//			['columnName' => 'id', 'type' => 'uuid'],
-//			['columnName' => 'name', 'type' => 'text'],
-//		];
-//		$primaryKeys = ['id'];
-//		$tableOptions = ['compactStorage' => true];
-//		$expectedCQL = 'CREATE TABLE test (id uuid,name text,PRIMARY KEY (id)) WITH COMPACT STORAGE;';
-		$this
-			->and($connectionMock = $this->getConnectionMock())
-			->and($clusterMock = $this->getClusterMock())
-			->and($sessionMock = $this->getSessionMock())
-			->and($clusterMock->getMockController()->connect = $sessionMock)
-			->and($connectionMock->setCluster($clusterMock))
-			->given($testedClass = new TestedSchemaManager($connectionMock))
-			->if($testedClass->createTable($tableName, $fields, $primaryKeys, $tableOptions))
-				->mock($connectionMock)
-				->call('prepare')
-				->withIdenticalArguments($expectedCQL)->once()
-				->call('execute')
-				->once()
-        ;
+        $this
+            ->and($connectionMock = $this->getConnectionMock())
+            ->and($clusterMock = $this->getClusterMock())
+            ->and($sessionMock = $this->getSessionMock())
+            ->and($clusterMock->getMockController()->connect = $sessionMock)
+            ->and($connectionMock->setCluster($clusterMock))
+            ->given($testedClass = new TestedSchemaManager($connectionMock))
+            ->if($testedClass->createTable($tableName, $fields, $primaryKeys, $tableOptions))
+            ->mock($connectionMock)
+            ->call('prepare')
+            ->withIdenticalArguments($expectedCQL)->once()
+            ->call('execute')
+            ->once();
     }
 
     protected function tableConfigProvider()
-	{
-		return [
-			[
-				'test',
-				[
-					['columnName' => 'id', 'type' => 'uuid'],
-					['columnName' => 'name', 'type' => 'text'],
-				],
-				['id'],
-				['compactStorage' => true],
-				'CREATE TABLE test (id uuid,name text,PRIMARY KEY (id)) WITH COMPACT STORAGE;'
-			],
-			[
-				'test',
-				[
-					['columnName' => 'id', 'type' => 'uuid'],
-					['columnName' => 'name', 'type' => 'text'],
-					['columnName' => 'lastname', 'type' => 'text'],
-					['columnName' => 'date', 'type' => 'timestamp'],
-				],
-				['id', 'date'],
-				[],
-				'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date));'
-			],
-			[
-				'test',
-				[
-					['columnName' => 'id', 'type' => 'uuid'],
-					['columnName' => 'name', 'type' => 'text'],
-					['columnName' => 'lastname', 'type' => 'text'],
-					['columnName' => 'date', 'type' => 'timestamp'],
-				],
-				['id', 'date'],
-				['clusteringOrder' => 'date DESC'],
-				'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH CLUSTERING ORDER BY (date DESC);'
-			],
-			[
-				'test',
-				[
-					['columnName' => 'id', 'type' => 'uuid'],
-					['columnName' => 'name', 'type' => 'text'],
-					['columnName' => 'lastname', 'type' => 'text'],
-					['columnName' => 'date', 'type' => 'timestamp'],
-				],
-				['id', 'date'],
-				['compactStorage' => true, 'clusteringOrder' => 'date DESC'],
-				'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (date DESC);'
-			],
-		];
-	}
+    {
+        return [
+            [
+                'test',
+                [
+                    ['columnName' => 'id', 'type' => 'uuid'],
+                    ['columnName' => 'name', 'type' => 'text'],
+                ],
+                ['id'],
+                ['compactStorage' => true],
+                'CREATE TABLE test (id uuid,name text,PRIMARY KEY (id)) WITH COMPACT STORAGE;'
+            ],
+            [
+                'test',
+                [
+                    ['columnName' => 'id', 'type' => 'uuid'],
+                    ['columnName' => 'name', 'type' => 'text'],
+                    ['columnName' => 'lastname', 'type' => 'text'],
+                    ['columnName' => 'date', 'type' => 'timestamp'],
+                ],
+                ['id', 'date'],
+                [],
+                'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date));'
+            ],
+            [
+                'test',
+                [
+                    ['columnName' => 'id', 'type' => 'uuid'],
+                    ['columnName' => 'name', 'type' => 'text'],
+                    ['columnName' => 'lastname', 'type' => 'text'],
+                    ['columnName' => 'date', 'type' => 'timestamp'],
+                ],
+                ['id', 'date'],
+                ['clusteringOrder' => 'date DESC'],
+                'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH CLUSTERING ORDER BY (date DESC);'
+            ],
+            [
+                'test',
+                [
+                    ['columnName' => 'id', 'type' => 'uuid'],
+                    ['columnName' => 'name', 'type' => 'text'],
+                    ['columnName' => 'lastname', 'type' => 'text'],
+                    ['columnName' => 'date', 'type' => 'timestamp'],
+                ],
+                ['id', 'date'],
+                ['compactStorage' => true, 'clusteringOrder' => 'date DESC'],
+                'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (date DESC);'
+            ],
+        ];
+    }
 
     private function getConnectionMock()
     {
         $mockConnection = new \mock\CassandraBundle\Cassandra\Connection(
-			[
-				'keyspace' => 'test',
-				'hosts' => ['127.0.0.1'],
-				'user' => '',
-				'password' => '',
-				'retries' => ['sync_requests' => 1],
-			]
-		);
+            [
+                'keyspace' => 'test',
+                'hosts' => ['127.0.0.1'],
+                'user' => '',
+                'password' => '',
+                'retries' => ['sync_requests' => 1],
+            ]
+        );
         return $mockConnection;
     }
 
-	private function getClusterMock()
-	{
-		$this->getMockGenerator()->shuntParentClassCalls();
+    private function getClusterMock()
+    {
+        $this->getMockGenerator()->shuntParentClassCalls();
 
-		return new \mock\Cassandra\Cluster();
-	}
+        return new \mock\Cassandra\Cluster();
+    }
 
-	private function getSessionMock($retry = 0, $error = false)
-	{
-		$this->getMockGenerator()->shuntParentClassCalls();
+    private function getSessionMock($retry = 0, $error = false)
+    {
+        $this->getMockGenerator()->shuntParentClassCalls();
 
-		$session = new \mock\Cassandra\Session();
-		$session->getMockController()->executeAsync = new \mock\Cassandra\Future();
-		$session->getMockController()->prepareAsync = new \mock\Cassandra\Future();
+        $session = new \mock\Cassandra\Session();
+        $session->getMockController()->executeAsync = new \mock\Cassandra\Future();
+        $session->getMockController()->prepareAsync = new \mock\Cassandra\Future();
 
-		$session->getMockController()->execute = function () use (&$retry, $error) {
-			if (($error && $retry <= 0) || ($retry > 0)) {
-				--$retry;
-				throw new \Cassandra\Exception\RuntimeException('runtime error');
-			}
-		};
+        $session->getMockController()->execute = function () use (&$retry, $error) {
+            if (($error && $retry <= 0) || ($retry > 0)) {
+                --$retry;
+                throw new \Cassandra\Exception\RuntimeException('runtime error');
+            }
+        };
 
-		return $session;
-	}
+        return $session;
+    }
 }


### PR DESCRIPTION
Currently for schema creation process in CassandraBundle, table annotation covers the following table 
 options :

- name => string which represents the table name
- indexes => array which represents the list of indexes for the table
- primaryKeys => array which represents the list of fields which composed the primary key of the table

The following options are also possible but don't impact table creation CQL build :
- repositoryClass
- defaultTtl
- ifNoExist

For my usage, I need to add table creation option "CLUSTERING ORDER" which allow to apply an default ordering for the table for select queries.
I also add COMPACT STORAGE table creation option according the official documentation : http://cassandra.apache.org/doc/latest/cql/ddl.html#create-table

I added some tests for SchemaManager class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hendra-huang/cassandrabundle/9)
<!-- Reviewable:end -->
