### PR TITLE
Add --dump-cql parameter for command create schema

### DIFF
--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -18,6 +18,7 @@ class SchemaManager
 
     /**
      * @param string $cql
+     *
      * @return string
      */
     private function _exec($cql)
@@ -26,6 +27,7 @@ class SchemaManager
             $statement = $this->connection->prepare($cql);
             $this->connection->execute($statement);
         }
+
         return $cql;
     }
 
@@ -39,9 +41,9 @@ class SchemaManager
 
     /**
      * @param string $name
-     * @param array $fields
-     * @param array $primaryKeyFields
-     * @param array $tableOptions
+     * @param array  $fields
+     * @param array  $primaryKeyFields
+     * @param array  $tableOptions
      *
      * @return string
      */
@@ -90,7 +92,7 @@ class SchemaManager
 
     /**
      * @param string $tableName
-     * @param array $indexes
+     * @param array  $indexes
      *
      * @return string
      */
@@ -100,6 +102,7 @@ class SchemaManager
         foreach ($indexes as $index) {
             $indexesCql[] = $this->createIndex($tableName, $index);
         }
+
         return implode(PHP_EOL, $indexesCql);
     }
 

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -8,6 +8,8 @@ class SchemaManager
 {
     protected $connection;
 
+    private $dumpCql = false;
+
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
@@ -15,8 +17,17 @@ class SchemaManager
 
     private function _exec($cql)
     {
+        if ($this->dumpCql) {
+            echo $cql . PHP_EOL;
+            return;
+        }
         $statement = $this->connection->prepare($cql);
         $this->connection->execute($statement);
+    }
+
+    public function forceDumpCql($dumpCql)
+    {
+        $this->dumpCql = $dumpCql;
     }
 
     public function createTable($name, $fields, $primaryKeyFields = [], $tableOptions = [])

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -87,7 +87,7 @@ class SchemaManager
      */
     public function dropTable($name)
     {
-        return $this->_exec(sprintf('DROP TABLE IF EXISTS %s', $name));
+        return $this->_exec(sprintf('DROP TABLE IF EXISTS %s;', $name));
     }
 
     /**
@@ -114,6 +114,6 @@ class SchemaManager
      */
     private function createIndex($tableName, $index)
     {
-        return $this->_exec(sprintf('CREATE INDEX ON %s (%s)', $tableName, $index));
+        return $this->_exec(sprintf('CREATE INDEX ON %s (%s);', $tableName, $index));
     }
 }

--- a/Cassandra/ORM/Tools/SchemaCreate.php
+++ b/Cassandra/ORM/Tools/SchemaCreate.php
@@ -15,6 +15,7 @@ class SchemaCreate
     {
         $em = $this->container->get(sprintf('cassandra.%s_entity_manager', $connection));
         $schemaManager = $em->getSchemaManager();
+        $dumpOutput = [];
         $schemaManager->forceDumpCql($dumpCql);
 
         $entityDirectoriesRegexp = '/src\/.*Entity\//';
@@ -50,13 +51,15 @@ class SchemaCreate
                 $tableOptions = $metadata->table['tableOptions'];
 
                 if ($tableName) {
-                    $schemaManager->dropTable($tableName);
-                    $schemaManager->createTable($tableName, $metadata->fieldMappings, $primaryKeys, $tableOptions);
-                    $schemaManager->createIndexes($tableName, $indexes);
+                    $dumpOutput[] = $schemaManager->dropTable($tableName);
+                    $dumpOutput[] = $schemaManager->createTable($tableName, $metadata->fieldMappings, $primaryKeys, $tableOptions);
+                    $dumpOutput[] = $schemaManager->createIndexes($tableName, $indexes);
                 }
             }
         }
 
         $em->closeAsync();
+
+        return $dumpOutput;
     }
 }

--- a/Cassandra/ORM/Tools/SchemaCreate.php
+++ b/Cassandra/ORM/Tools/SchemaCreate.php
@@ -11,10 +11,11 @@ class SchemaCreate
         $this->container = $container;
     }
 
-    public function execute($connection = 'default')
+    public function execute($connection = 'default', $dumpCql = false)
     {
         $em = $this->container->get(sprintf('cassandra.%s_entity_manager', $connection));
         $schemaManager = $em->getSchemaManager();
+        $schemaManager->forceDumpCql($dumpCql);
 
         $entityDirectoriesRegexp = '/src\/.*Entity\//';
         $entityDirectories = $em->getTargetedEntityDirectories();

--- a/Command/SchemaCreateCommand.php
+++ b/Command/SchemaCreateCommand.php
@@ -41,6 +41,7 @@ class SchemaCreateCommand extends ContainerAwareCommand
 
         if ($dumpCql) {
             $output->writeln(sprintf('CQL schema dump for connection %', $connection));
+            $output->writeln('#######');
             $output->writeln(implode(PHP_EOL, $dumpOutputs));
         } else {
             $output->writeln('Cassandra schema updated successfully!');

--- a/Command/SchemaCreateCommand.php
+++ b/Command/SchemaCreateCommand.php
@@ -37,8 +37,15 @@ class SchemaCreateCommand extends ContainerAwareCommand
         $schemaCreate = $container->get('cassandra.tools.schema_create');
         $connection = $input->getArgument('connection') ?: 'default';
         $dumpCql = true === $input->getOption('dump-cql');
-        $schemaCreate->execute($connection, $dumpCql);
+        $dumpOutputs = $schemaCreate->execute($connection, $dumpCql);
 
-        $output->writeln('Cassandra schema updated successfully!');
+        if ($dumpCql) {
+            $output->writeln(sprintf('CQL schema dump for connection %', $connection));
+            $output->writeln(implode(PHP_EOL, $dumpOutputs));
+        } else {
+            $output->writeln('Cassandra schema updated successfully!');
+        }
+
+
     }
 }

--- a/Command/SchemaCreateCommand.php
+++ b/Command/SchemaCreateCommand.php
@@ -45,7 +45,5 @@ class SchemaCreateCommand extends ContainerAwareCommand
         } else {
             $output->writeln('Cassandra schema updated successfully!');
         }
-
-
     }
 }

--- a/Command/SchemaCreateCommand.php
+++ b/Command/SchemaCreateCommand.php
@@ -5,6 +5,7 @@ namespace CassandraBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -19,6 +20,12 @@ class SchemaCreateCommand extends ContainerAwareCommand
                 'connection',
                 InputArgument::OPTIONAL,
                 'Connection of cassandra'
+            )
+            ->addOption(
+                'dump-cql',
+                null,
+                InputOption::VALUE_NONE,
+                'Dumps the generated CQL statements to the screen (does not execute them).'
             );
     }
 
@@ -28,7 +35,9 @@ class SchemaCreateCommand extends ContainerAwareCommand
 
         $container = $this->getContainer();
         $schemaCreate = $container->get('cassandra.tools.schema_create');
-        $schemaCreate->execute($input->getArgument('connection') ?: 'default');
+        $connection = $input->getArgument('connection') ?: 'default';
+        $dumpCql = true === $input->getOption('dump-cql');
+        $schemaCreate->execute($connection, $dumpCql);
 
         $output->writeln('Cassandra schema updated successfully!');
     }

--- a/Tests/Units/Cassandra/ORM/SchemaManager.php
+++ b/Tests/Units/Cassandra/ORM/SchemaManager.php
@@ -10,7 +10,7 @@ class SchemaManager extends test
     /**
      * @dataProvider tableConfigProvider
      */
-    public function testCreateTable($tableName, $fields, $primaryKeys, $tableOptions, $expectedCQL)
+    public function testICreateTable($tableName, $fields, $primaryKeys, $tableOptions, $expectedCQL)
     {
         $this
             ->and($connectionMock = $this->getConnectionMock())
@@ -25,6 +25,27 @@ class SchemaManager extends test
             ->withIdenticalArguments($expectedCQL)->once()
             ->call('execute')
             ->once();
+    }
+
+    /**
+     * @dataProvider tableConfigProvider
+     */
+    public function testIWontCreateTableWhenDumpCQL($tableName, $fields, $primaryKeys, $tableOptions, $expectedCQL)
+    {
+        $this
+            ->and($connectionMock = $this->getConnectionMock())
+            ->and($clusterMock = $this->getClusterMock())
+            ->and($sessionMock = $this->getSessionMock())
+            ->and($clusterMock->getMockController()->connect = $sessionMock)
+            ->and($connectionMock->setCluster($clusterMock))
+            ->given($testedClass = new TestedSchemaManager($connectionMock))
+            ->if($testedClass->forceDumpCql(true))
+            ->and($testedClass->createTable($tableName, $fields, $primaryKeys, $tableOptions))
+            ->mock($connectionMock)
+            ->call('prepare')
+            ->never()
+            ->call('execute')
+            ->never();
     }
 
     protected function tableConfigProvider()


### PR DESCRIPTION
I add the command option **--dump-cql** to display the Cassandra queries instead executing schema creation CQL on clusters.

**TODO**

- Unit tests are not done yet. I will add tomorrow.
- SchemaManager is doing echo... it's quite uggly... I am propably going to let that responsability to SchemaCreate by returning CQL from _exec method

Any feedback on the todo list ?

TODO done :-)

The output of command when --dump-cql option will be defined is :
```
CQL schema dump for connection 
#######
DROP TABLE IF EXISTS table_name;
CREATE TABLE table_name (id text,name text,city text,PRIMARY KEY (id,name)) WITH CLUSTERING ORDER BY (name DESC);
CREATE INDEX ON table_name(city);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hendra-huang/cassandrabundle/12)
<!-- Reviewable:end -->
