### PR TITLE
Add management of all the table options like ttl, comment... in annotations

### DIFF
--- a/Cassandra/ORM/Mapping/Table.php
+++ b/Cassandra/ORM/Mapping/Table.php
@@ -46,5 +46,16 @@ final class Table extends Annotation
     public $tableOptions = [
         'compactStorage' => false,
         'clusteringOrder' => null,
+        'comment' => null,
+        'speculative_retry' => null,
+        'additional_write_policy' => null,
+        'gc_grace_seconds' => null,
+        'bloom_filter_fp_chance' => null,
+        'default_time_to_live' => null,
+        'compaction' => null,
+        'compression' => null,
+        'caching' => null,
+        'memtable_flush_period_in_ms' => null,
+        'read_repair' => null,
     ];
 }

--- a/Cassandra/ORM/SchemaException.php
+++ b/Cassandra/ORM/SchemaException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CassandraBundle\Cassandra\ORM;
+
+class SchemaException extends \Exception
+{
+    /**
+     * @param string $mode
+     *
+     * @return ORMException
+     */
+    public static function wrongFormatForNumericTableOption($optionName, $optionValue)
+    {
+        return new self(sprintf('Invalid numeric format for table option "%s", "%s" is not numeric', $optionName, $optionValue));
+    }
+}

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -64,12 +64,14 @@ class SchemaManager
 
         if (!empty($tableOptions)) {
             $tableOptionsParamCQL = [];
-            if (isset($tableOptions['compactStorage']) && false !== $tableOptions['compactStorage']) {
-                $tableOptionsParamCQL[] = 'COMPACT STORAGE';
-            }
-
-            if (isset($tableOptions['clusteringOrder']) && null !== $tableOptions['clusteringOrder']) {
-                $tableOptionsParamCQL[] = sprintf('CLUSTERING ORDER BY (%s)', $tableOptions['clusteringOrder']);
+            foreach ($tableOptions as $optionName => $optionValue) {
+                if ($optionName === 'compactStorage' && false !== $optionValue) {
+                    $tableOptionsParamCQL[] = 'COMPACT STORAGE';
+                } elseif ($optionName === 'clusteringOrder' && null !== $optionValue) {
+                    $tableOptionsParamCQL[] = sprintf('CLUSTERING ORDER BY (%s)', $optionValue);
+                } elseif (!in_array($optionName, ['compactStorage', 'clusteringOrder'])) {
+                    $tableOptionsParamCQL[] = $this->formatOption($optionName, $optionValue);
+                }
             }
 
             if (!empty($tableOptionsParamCQL)) {
@@ -78,6 +80,23 @@ class SchemaManager
         }
 
         return $this->_exec(sprintf('CREATE TABLE %s (%s%s)%s;', $name, implode(',', $fieldsWithType), $primaryKeyCQL, $tableOptionsCQL));
+    }
+
+    private function formatOption($optionName, $optionValue)
+    {
+        // numeric type : float or int
+        if (in_array($optionName, ['gc_grace_seconds' ,'memtable_flush_period_in_ms', 'default_time_to_live', 'bloom_filter_fp_chance'])) {
+            if (!is_numeric($optionValue)) {
+                throw SchemaException::wrongFormatForNumericTableOption($optionName, $optionValue);
+            }
+            return sprintf('%s = %s', $optionName, $optionValue);
+        }
+        // map type
+        if (in_array($optionName, ['compaction', 'compression', 'caching'])) {
+            return sprintf('%s = %s', $optionName, $optionValue);
+        }
+        // string type
+        return sprintf('%s = "%s"', $optionName, addslashes($optionValue));
     }
 
     /**

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -97,7 +97,7 @@ class SchemaManager
             return sprintf('%s = %s', $optionName, $optionValue);
         }
         // string type
-        return sprintf('%s = "%s"', $optionName, addslashes($optionValue));
+        return sprintf("%s = '%s'", $optionName, addslashes($optionValue));
     }
 
     /**

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -65,11 +65,11 @@ class SchemaManager
         if (!empty($tableOptions)) {
             $tableOptionsParamCQL = [];
             foreach ($tableOptions as $optionName => $optionValue) {
-                if ($optionName === 'compactStorage' && false !== $optionValue) {
+                if ('compactStorage' === $optionName && false !== $optionValue) {
                     $tableOptionsParamCQL[] = 'COMPACT STORAGE';
-                } elseif ($optionName === 'clusteringOrder' && null !== $optionValue) {
+                } elseif ('clusteringOrder' === $optionName && null !== $optionValue) {
                     $tableOptionsParamCQL[] = sprintf('CLUSTERING ORDER BY (%s)', $optionValue);
-                } elseif (!in_array($optionName, ['compactStorage', 'clusteringOrder'])) {
+                } elseif (!\in_array($optionName, ['compactStorage', 'clusteringOrder'])) {
                     $tableOptionsParamCQL[] = $this->formatOption($optionName, $optionValue);
                 }
             }
@@ -85,14 +85,15 @@ class SchemaManager
     private function formatOption($optionName, $optionValue)
     {
         // numeric type : float or int
-        if (in_array($optionName, ['gc_grace_seconds' ,'memtable_flush_period_in_ms', 'default_time_to_live', 'bloom_filter_fp_chance'])) {
+        if (\in_array($optionName, ['gc_grace_seconds' ,'memtable_flush_period_in_ms', 'default_time_to_live', 'bloom_filter_fp_chance'])) {
             if (!is_numeric($optionValue)) {
                 throw SchemaException::wrongFormatForNumericTableOption($optionName, $optionValue);
             }
+
             return sprintf('%s = %s', $optionName, $optionValue);
         }
         // map type
-        if (in_array($optionName, ['compaction', 'compression', 'caching'])) {
+        if (\in_array($optionName, ['compaction', 'compression', 'caching'])) {
             return sprintf('%s = %s', $optionName, $optionValue);
         }
         // string type

--- a/Cassandra/ORM/SchemaManager.php
+++ b/Cassandra/ORM/SchemaManager.php
@@ -85,7 +85,7 @@ class SchemaManager
     private function formatOption($optionName, $optionValue)
     {
         // numeric type : float or int
-        if (\in_array($optionName, ['gc_grace_seconds' ,'memtable_flush_period_in_ms', 'default_time_to_live', 'bloom_filter_fp_chance'])) {
+        if (\in_array($optionName, ['gc_grace_seconds', 'memtable_flush_period_in_ms', 'default_time_to_live', 'bloom_filter_fp_chance'])) {
             if (!is_numeric($optionValue)) {
                 throw SchemaException::wrongFormatForNumericTableOption($optionName, $optionValue);
             }

--- a/Tests/Units/Cassandra/ORM/SchemaManager.php
+++ b/Tests/Units/Cassandra/ORM/SchemaManager.php
@@ -97,6 +97,30 @@ class SchemaManager extends test
                 ['compactStorage' => true, 'clusteringOrder' => 'date DESC'],
                 'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (date DESC);',
             ],
+            [
+                'test',
+                [
+                    ['columnName' => 'id', 'type' => 'uuid'],
+                    ['columnName' => 'name', 'type' => 'text'],
+                    ['columnName' => 'lastname', 'type' => 'text'],
+                    ['columnName' => 'date', 'type' => 'timestamp'],
+                ],
+                ['id', 'date'],
+                ['compactStorage' => true, 'comment' => 'A comment to describe the objective of the table'],
+                'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND comment = "A comment to describe the objective of the table";',
+            ],
+            [
+                'test',
+                [
+                    ['columnName' => 'id', 'type' => 'uuid'],
+                    ['columnName' => 'name', 'type' => 'text'],
+                    ['columnName' => 'lastname', 'type' => 'text'],
+                    ['columnName' => 'date', 'type' => 'timestamp'],
+                ],
+                ['id', 'date'],
+                ['compaction' => "{ 'class' : 'LeveledCompactionStrategy' }"],
+                "CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH compaction = { 'class' : 'LeveledCompactionStrategy' };",
+            ],
         ];
     }
 

--- a/Tests/Units/Cassandra/ORM/SchemaManager.php
+++ b/Tests/Units/Cassandra/ORM/SchemaManager.php
@@ -107,7 +107,7 @@ class SchemaManager extends test
                 ],
                 ['id', 'date'],
                 ['compactStorage' => true, 'comment' => 'A comment to describe the objective of the table'],
-                'CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND comment = "A comment to describe the objective of the table";',
+                "CREATE TABLE test (id uuid,name text,lastname text,date timestamp,PRIMARY KEY (id,date)) WITH COMPACT STORAGE AND comment = 'A comment to describe the objective of the table';",
             ],
             [
                 'test',


### PR DESCRIPTION
In addition to clusteringOrder and compactStorage, let’s add in tableOptions property additional cassandra table options as TTL...

Here is the list :

![image](https://user-images.githubusercontent.com/48293000/55970219-71b80c80-5c7f-11e9-8a86-e0ea00e6f75b.png)

Let’s use simple type for all those options :

- Check if float for bloom_filter_fp_chance
- Check if int for gc_grace_seconds ,memtable_flush_period_in_ms and default_time_to_live
- Check if map for compaction, compression and caching
- string for others

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hendra-huang/cassandrabundle/13)
<!-- Reviewable:end -->
